### PR TITLE
new_scaled_dims vs new_dims

### DIFF
--- a/src/software_renderer.rs
+++ b/src/software_renderer.rs
@@ -12,7 +12,7 @@ pub fn render_scene(
     bottom_image: &mut Option<PietImage>,
     renderer: &mut Renderer,
     state: &LayoutState,
-) -> Option<(f32, f32)> {
+) -> Option<(f64, f64)> {
     let size = paint_ctx.size();
     let scale = paint_ctx.scale();
     let scaled_width = size.width * scale.x();
@@ -21,7 +21,8 @@ pub fn render_scene(
     let (width, height) = (scaled_width as u32, scaled_height as u32);
     let dimensions = renderer.image().dimensions();
 
-    let new_dims = renderer.render(state, [width, height]);
+    let new_scaled_dims = renderer.render(state, image_cache, [width, height]);
+    let new_dims = new_scaled_dims.map(|[w, h]| scale.px_to_dp_xy(w, h));
 
     let bottom_image = if bottom_image.is_none() || dimensions != (width, height) {
         bottom_image.insert(

--- a/src/timer_form.rs
+++ b/src/timer_form.rs
@@ -711,7 +711,7 @@ impl<T: Widget<MainState>> Widget<MainState> for WithMenu<T> {
             &layout_data.layout_state,
         ) {
             ctx.window()
-                .set_size(Size::new(new_width as _, new_height as _));
+                .set_size(Size::new(new_width, new_height));
         }
     }
 }

--- a/src/timer_form.rs
+++ b/src/timer_form.rs
@@ -710,8 +710,7 @@ impl<T: Widget<MainState>> Widget<MainState> for WithMenu<T> {
             &mut self.renderer,
             &layout_data.layout_state,
         ) {
-            ctx.window()
-                .set_size(Size::new(new_width, new_height));
+            ctx.window().set_size(Size::new(new_width, new_height));
         }
     }
 }


### PR DESCRIPTION
Fixes #3 by using `scale.px_to_dp_xy` to convert back from a post-scale size in pixels to pre-scale size in display points.